### PR TITLE
Allow skipping the whole plugin execution. (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- skip parameter to skip configurable rules or whole plugin execution
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,51 @@ So your config would become something like :
 </plugin>
 ```
 
+## Skipping rules
+
+In case of adding **ArchUnit Maven plugin** to a legacy code base you might not be able to enforce all rules immediately.
+You may add **ArchUnit Maven plugin** to a parent POM of your Maven artifacts and still be able to skip execution in child
+projects by using the skip-configuration.
+
+### Skipping just one rule
+
+Most of the time you add a new rule to your **ArchUnit Maven plugin** (which might immediately be available in all of
+your artifacts) but the issues **ArchUnit** reveals using your rule may not be fixed as soon as you need to release the
+next version of your artifacts.
+
+To skip a rule temporarily, configure it like
+
+```xml
+<properties>
+  <archunit.customrule.skip>false</archunit.customrule.skip>
+</properties>
+<!-- and inside your plugin's configuration -->
+<configurableRule>
+  <rule>com.mycompany.rules.CustomArchRule</rule>
+  <skip>${archunit.customrule.skip}</skip>
+  <!-- detailed configuration omitted -->
+</configurableRule>
+```
+
+and then your slow-to-be-fixed-artifacts my override the property `<archunit.customrule.skip>true</archunit.customrule.skip>`
+
+### Skipping the whole plugin
+
+If even skipping certain rules doesn't fit your needs, configure to skip the whole plugin execution:
+
+```xml
+<properties>
+  <archunit.skip>false</archunit.skip>
+</properties>
+<!-- and then inside the ArchUnit Maven plugin -->
+  <configuration>
+    <skip>${archunit.skip}</skip>
+  </configuration>
+```
+
+and then you can switch the parameter `archunit.skip` either on runtime (via `-Darchunit.skip=true`) or statically in child modules.
+
+
 ## Contribute !
 
 If you don't want to package your rules separately and/or feel they could be useful to others, we can make your rules part of default ArchUnit Maven plugin package, so that they can be used out of the box by anyone : don't hesitate to send us a pull request ! have a look at the [code](./src/main/java/com/societegenerale/commons/plugin/rules), it's very easy to add one.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.societegenerale.commons</groupId>
     <artifactId>arch-unit-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <name>ArchUnit Maven plugin</name>
 

--- a/src/main/java/com/societegenerale/commons/plugin/ArchUnitMojo.java
+++ b/src/main/java/com/societegenerale/commons/plugin/ArchUnitMojo.java
@@ -11,6 +11,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -29,6 +31,23 @@ import static java.net.URLClassLoader.newInstance;
  */
 @Mojo(name = "arch-test", requiresDependencyResolution = ResolutionScope.TEST)
 public class ArchUnitMojo extends AbstractMojo {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArchUnitMojo.class);
+
+    /**
+     * Skips all processing performed by this plugin.
+     *
+     * <pre>
+     * {@code
+     * ...
+     * <configuration>
+     *   <skip>false</skip>
+     * </configuration>
+     * ...
+     * }
+     * </pre>
+     */
+    @Parameter(defaultValue = "false", property = "archunit.skip", required = false)
+    private boolean skip;
 
     @Parameter(property = "projectPath")
     private String projectPath = "./target";
@@ -49,6 +68,10 @@ public class ArchUnitMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoFailureException {
+        if (skip) {
+            LOGGER.info("Skipping execution.");
+            return;
+        }
 
         if (!rules.isValid()) {
             throw new MojoFailureException("Arch unit Plugin should have at least one preconfigured/configurable rule");

--- a/src/main/java/com/societegenerale/commons/plugin/model/ConfigurableRule.java
+++ b/src/main/java/com/societegenerale/commons/plugin/model/ConfigurableRule.java
@@ -16,6 +16,9 @@ public class ConfigurableRule {
   @Parameter(property ="checks")
   private List<String> checks = new ArrayList<>();
 
+  @Parameter(defaultValue = "false", required = false)
+  private boolean skip;
+
   public List<String> getChecks() {
     return checks;
   }
@@ -38,5 +41,13 @@ public class ConfigurableRule {
 
   public void setApplyOn(ApplyOn applyOn) {
     this.applyOn = applyOn;
+  }
+
+  public boolean isSkip() {
+    return skip;
+  }
+
+  public void setSkip(boolean skip) {
+    this.skip = skip;
   }
 }

--- a/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
@@ -5,6 +5,8 @@ import java.lang.reflect.Method;
 import com.societegenerale.commons.plugin.model.ConfigurableRule;
 import com.societegenerale.commons.plugin.service.InvokableRules.InvocationResult;
 import com.tngtech.archunit.core.domain.JavaClasses;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.societegenerale.commons.plugin.rules.ArchRuleTest.SRC_CLASSES_FOLDER;
 import static com.societegenerale.commons.plugin.rules.ArchRuleTest.TEST_CLASSES_FOLDER;
@@ -12,6 +14,7 @@ import static com.societegenerale.commons.plugin.utils.ArchUtils.importAllClasse
 import static com.societegenerale.commons.plugin.utils.ReflectionUtils.loadClassWithContextClassLoader;
 
 public class RuleInvokerService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RuleInvokerService.class);
 
     private static final String EXECUTE_METHOD_NAME = "execute";
 
@@ -29,6 +32,10 @@ public class RuleInvokerService {
     }
 
     public String invokeConfigurableRules(ConfigurableRule rule, String projectPath) {
+        if(rule.isSkip()) {
+            LOGGER.info("Skipping rule {}", rule.getRule());
+            return "";
+        }
 
         InvokableRules invokableRules = InvokableRules.of(rule.getRule(), rule.getChecks());
 

--- a/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
@@ -31,8 +31,7 @@ import org.mockito.junit.MockitoRule;
 
 import static com.tngtech.junit.dataprovider.DataProviders.testForEach;
 import static java.util.Arrays.stream;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 @RunWith(DataProviderRunner.class)
 public class ArchUnitMojoTest {
@@ -50,6 +49,7 @@ public class ArchUnitMojoTest {
   private MavenProject mavenProject;
 
   private PlexusConfiguration pluginConfiguration;
+
 
   // @formatter:off
   private static final String pomWithNoRule =
@@ -186,6 +186,30 @@ public class ArchUnitMojoTest {
     executeAndExpectViolations(mojo,
         expectRuleFailure("classes should be annotated with @Test").ofAnyKind(),
         expectRuleFailure("classes should not use Powermock").ofAnyKind());
+  }
+
+  @Test
+  public void shouldNotExecuteConfigurableRule_and_PreConfiguredRule_IfSkipIsTrue() throws Exception {
+
+    PlexusConfiguration configurableRule = new DefaultPlexusConfiguration("configurableRule");
+
+    configurableRule.addChild("rule", MyCustomRules.class.getName());
+    configurableRule.addChild(buildChecksBlock("annotatedWithTest_asField"));
+    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.commons.plugin.rules.classesForTests.specificCase", "test"));
+
+    PlexusConfiguration configurableRules = pluginConfiguration.getChild("rules").getChild("configurableRules");
+    configurableRules.addChild(configurableRule);
+
+    PlexusConfiguration preConfiguredRules = pluginConfiguration.getChild("rules").getChild("preConfiguredRules");
+    preConfiguredRules.addChild("rule", NoPowerMockRuleTest.class.getName());
+
+    pluginConfiguration.getChild("skip").setValue("true");
+
+    ArchUnitMojo mojo = (ArchUnitMojo) mojoRule.configureMojo(archUnitMojo, pluginConfiguration);
+
+    assertThatCode(() -> {
+      mojo.execute();
+    }).doesNotThrowAnyException();
   }
 
   private void executeAndExpectViolations(ArchUnitMojo mojo, ExpectedRuleFailure... expectedRuleFailures) {

--- a/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
@@ -28,6 +28,20 @@ public class RuleInvokerServiceTest {
     }
 
     @Test
+    public void shouldNotExecuteSkippedConfigurableRules() {
+
+        ApplyOn applyOn = new ApplyOn("com.societegenerale.commons.plugin.rules","test");
+
+        configurableRule.setRule(DummyCustomRule.class.getName());
+        configurableRule.setApplyOn(applyOn);
+        configurableRule.setChecks(Arrays.asList("annotatedWithTest","resideInMyPackage"));
+        configurableRule.setSkip(true);
+
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
+        assertThat(errorMessage).isEmpty();
+    }
+
+    @Test
     public void shouldExecute2ConfigurableRulesOnTest() {
 
         ApplyOn applyOn = new ApplyOn("com.societegenerale.commons.plugin.rules","test");


### PR DESCRIPTION
* Allow skipping configurable rules.

* explicitly asserting that no exception is thrown when execution is skipped

## Summary

<!-- Provide a general summary description of your changes -->

## Details

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Which environnment is/are impacted ? -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I've added tests for my code.
- [ ] Documentation has been updated accordingly to this PR


## Related issue : 
<!-- If it fixes an open issue, please link to the issue here. -->
